### PR TITLE
Change python' to 'python2'

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import os


### PR DESCRIPTION
On Arch Linux, `python` is a symlink to `python3`, which breaks the script because of incompatibility.