### PR TITLE
ignore tags file

### DIFF
--- a/bin/lib/dot/core.py
+++ b/bin/lib/dot/core.py
@@ -136,7 +136,7 @@ def create_tree_from_text(text):
 
 def create_tree_from_filesystem(base_dir, envs):
     ignored_dirs = {'.git'}
-    ignored_files_re = re.compile(ur'(readme.*|news|changelog.*|.gitignore)',
+    ignored_files_re = re.compile(ur'(readme.*|news|changelog.*|.gitignore|tags)',
                                   re.I)
     base_dir_len = len(base_dir)
 


### PR DESCRIPTION
tags files are commonly generated by text editors.
Ideally files that are in the repo .gitignore shouldn't be symlinked. But as this might have unintended consequences, I reckon adding tags to the ignore list is a good idea.