### PR TITLE
Specify ignored files regex in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !/bin
 !/README.md
 !/CHANGELOG.md
+!/.ignored_files

--- a/.ignored_files
+++ b/.ignored_files
@@ -1,0 +1,9 @@
+# List of files to be ignored, not copied
+readme.*
+news
+licence
+license
+changelog.*
+.gitignore
+tags
+.gitmodules

--- a/bin/lib/dot/core.py
+++ b/bin/lib/dot/core.py
@@ -136,8 +136,20 @@ def create_tree_from_text(text):
 
 def create_tree_from_filesystem(base_dir, envs):
     ignored_dirs = {'.git'}
-    ignored_files_re = re.compile(ur'(readme.*|news|licence|license|changelog.*|.gitignore|tags)$',
-                                  re.I)
+    # read ignored files from file.
+    ignored_files_config = os.path.join(base_dir, '.ignored_files')
+    if (os.path.isfile(ignored_files_config)):
+        ignored_files_list = []
+        # This just reads every line and adds it to the regex directly, so probably will break with some input.
+        for line in open(ignored_files_config, 'r'):
+            file_name = line.rstrip() # remove whitespace and newlines
+            if (file_name and not file_name.startswith('#')): #check if line is empty and not a comment
+                ignored_files_list.append(file_name)
+        ignored_files = '(' + "|".join(ignored_files_list) + ')$' #format for regex
+    else:
+        # default
+        ignored_files = ur'(readme.*|news|licence|license|changelog.*|.gitignore|tags)$'
+    ignored_files_re = re.compile(ignored_files, re.I)
     base_dir_len = len(base_dir)
 
     text = u''


### PR DESCRIPTION
I wanted to add `.gitmodules` to the list of ignored files. Instead of adding it to the list of ignored files in code, I think it is nicer to have a config file for this.
This is optional, i.e. if no such file exists the default settings are used.
My python knowledge is somewhat limited, so apologies if it doesn't fulfill python standards. 