### PR TITLE
added .gitattributes to .dotignore

### DIFF
--- a/.dotignore
+++ b/.dotignore
@@ -9,3 +9,4 @@ changelog.*
 tags
 .gitmodules
 .*\.sw.
+.gitattributes


### PR DESCRIPTION
.gitattributes can be a per repo file which causes dot filter throw errors when linking.
One of the common usages of this file is when a repo is worked on cross platform in order to keep line endings consistent.

See the "End-of-line conversion" section in this doc for further info.
https://www.git-scm.com/docs/gitattributes